### PR TITLE
Generate url slugs based on post title

### DIFF
--- a/src/_content/posts/creating-posts.md
+++ b/src/_content/posts/creating-posts.md
@@ -1,7 +1,6 @@
 ---
 title: Creating posts 
 author: Jan De Wilde
-permalink: /creating-posts/
 date: 2020-08-06
 ---
 

--- a/src/_content/posts/hello-world.md
+++ b/src/_content/posts/hello-world.md
@@ -1,7 +1,6 @@
 ---
 title: Hello World
 author: Jan De Wilde
-permalink: /hello-world/
 date: 2020-08-06
 ---
 

--- a/src/_content/posts/how-deep-is-the-pool.md
+++ b/src/_content/posts/how-deep-is-the-pool.md
@@ -2,7 +2,6 @@
 title: How deep is that pool?
 subtitle: The mathematics of COVID-19 testing
 author: John Peach
-permalink: /how-deep-is-that-pool/
 date: 2020-08-07
 tags: [math, covid-19]
 ---

--- a/src/_content/posts/local-development.md
+++ b/src/_content/posts/local-development.md
@@ -1,7 +1,6 @@
 ---
 title: Local development configuration
 author: Jan De Wilde
-permalink: /local-development/
 date: 2020-08-06
 ---
 

--- a/src/_content/posts/posts.json
+++ b/src/_content/posts/posts.json
@@ -1,4 +1,5 @@
 {
   "layout": "blog.njk",
+  "permalink": "/blog/{{ title | slug }}/index.html",
   "tags": ["posts"]
 }


### PR DESCRIPTION
@XerxesZorgon No longer a need to specify the `permalink` in a blog post's frontmatter. It gets derived from the `title` now.